### PR TITLE
Fix missing Ukrainian in language picker

### DIFF
--- a/Ukrainian/main/framework-res.apk/res/values-uk-rUA/arrays.xml
+++ b/Ukrainian/main/framework-res.apk/res/values-uk-rUA/arrays.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer-array name="maps_starting_lat_lng">
+        <item>48379433</item>
+        <item>31165580</item>
+    </integer-array>
+    <integer-array name="maps_starting_zoom">
+        <item>3</item>
+    </integer-array>
+</resources>


### PR DESCRIPTION
This file is not optional and has to be in values-uk-rUA, just like any other language.